### PR TITLE
Add Ethereum logging

### DIFF
--- a/DockerHub/Dockerfile
+++ b/DockerHub/Dockerfile
@@ -1,5 +1,5 @@
 # Select source image
-FROM node:wheezy
+FROM node:stretch
 
 # Install all dependencies
 RUN apt-get update -q && apt-get upgrade -y --no-install-recommends

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Select source image
-FROM node:wheezy
+FROM node:stretch
 
 # Install all dependencies
 RUN apt-get update

--- a/config/opal.interface.sample.config.js
+++ b/config/opal.interface.sample.config.js
@@ -7,5 +7,53 @@ module.exports = {
     algoServiceURL: 'http://algoService:80',
     algorithmsDirectory: 'algorithms',
     auditDirectory: 'audit',
-    bcryptSalt:'$2b$14$2uYOq0IOSU5PViie2W8HU.'
+    bcryptSalt:'$2b$14$2uYOq0IOSU5PViie2W8HU.',
+    ethereum: {
+        enabled: true,
+        url: 'http://ganache:8545',
+        account: '0xe092b1fa25df5786d151246e492eed3d15ea4daa',
+        password: '',
+        gasPrice: 10,
+        contract: {
+            "abi": [
+                {
+                    "constant": false,
+                    "inputs": [
+                        {
+                            "name": "_hash",
+                            "type": "uint256"
+                        }
+                    ],
+                    "name": "log",
+                    "outputs": [],
+                    "payable": false,
+                    "stateMutability": "nonpayable",
+                    "type": "function",
+                    "signature": "0xf82c50f1"
+                },
+                {
+                    "inputs": [],
+                    "payable": false,
+                    "stateMutability": "nonpayable",
+                    "type": "constructor",
+                    "signature": "constructor"
+                },
+                {
+                    "anonymous": false,
+                    "inputs": [
+                        {
+                            "indexed": true,
+                            "name": "hash",
+                            "type": "uint256"
+                        }
+                    ],
+                    "name": "Logged",
+                    "type": "event",
+                    "signature": "0x2adf2e2e5f5d116e0d0e1f0231d3f5b75916c3d37d9a16ce060f634cbcc61430"
+                }
+            ],
+            "address": "0xE6042703475D0dd1bC2eB564a55F1832c2527171"
+        }
+    }
+
 };

--- a/config/opal.interface.test.config.js
+++ b/config/opal.interface.test.config.js
@@ -7,5 +7,17 @@ module.exports = {
     algoServiceURL: 'http://algoservice:3001',
     algorithmsDirectory: '/usr/app/algorithms',
     auditDirectory: '/usr/app/audit',
-    bcryptSalt:'$2b$14$2uYOq0IOSU5PViie2W8HU.'
+    bcryptSalt:'$2b$14$2uYOq0IOSU5PViie2W8HU.',
+    ethereum: {
+        enabled: false,
+        url: '',
+        account: '',
+        password: '',
+        gasPrice: 0,
+        contract: {
+            "abi": [],
+            "address": ""
+        }
+    }
+
 };

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "express": "^4.16.3",
     "fs-extra": "^5.0.0",
     "mongodb": "^2.2.35",
-    "opal-utils": "git+https://github.com/dsi-icl/OPAL-Utils.git"
+    "opal-utils": "git+https://github.com/dsi-icl/OPAL-Utils.git",
+    "web3": "^1.0.0-beta.34"
   }
 }

--- a/src/core/ethereumLogger.js
+++ b/src/core/ethereumLogger.js
@@ -1,0 +1,100 @@
+const Web3 = require('web3');
+
+/**
+ * @fn EthereumLogger
+ * @desc Service for logging hashes to Ethereum network
+ * @param ethereumURL
+ * @param ethereumAccount
+ * @param ethereumPassword
+ * @param contractABI
+ * @param contractAddress
+ * @param gasPrice
+ * @constructor
+ */
+function EthereumLogger(ethereumURL, ethereumAccount, ethereumPassword, contractABI, contractAddress, gasPrice, enabled) {
+    let _this = this;
+    _this._url = ethereumURL;
+    _this._account = ethereumAccount;
+    _this._password = ethereumPassword;
+    _this._contract = {
+        abi: contractABI,
+        address: contractAddress
+    };
+    _this._gasPrice = gasPrice;
+    _this._enabled = enabled;
+    if (_this._enabled) {
+        // Open connection to Ethereum node
+        _this.web3 = new Web3(_this._url);
+        _this.web3.eth.defaultAccount = _this._account;
+        // Ready Logger smart contract for use.
+        // Note that this won't fail if the contract doesn't exist.
+        _this._contract = new _this.web3.eth.Contract(_this._contract.abi, _this._contract.address);
+    }
+
+    // Bind member functions
+    this.sha3 = EthereumLogger.prototype.sha3.bind(this);
+    this.logHash = EthereumLogger.prototype.logHash.bind(this);
+
+    // Bind private member functions
+    this._unlockAccount = EthereumLogger.prototype._unlockAccount.bind(this);
+}
+
+/**
+ * @fn sha3
+ * @desc Method that takes a string and returns a 256-bit hash suitable for logging to Ethereum.
+ * @param string The string to be hashed.
+ */
+EthereumLogger.prototype.sha3 = function (string) {
+    let _this = this;
+    return _this.web3.utils.sha3(string);
+}
+
+/**
+ * @fn logHash
+ * @desc Method that logs a 256-bit hash to a predefined smart contract on the Ethereum blockchain.
+ * @param hash The 256-bit number to be logged. May be a string or number but must be convertible by web3.utils.toBN().
+ */
+EthereumLogger.prototype.logHash = function (hash) {
+    let _this = this;
+    if (!_this._enabled) {
+        return;
+    }
+    _this._unlockAccount((result) => {
+        // Convert to big number
+        let value = _this.web3.utils.toBN(hash);
+        // Actually send transaction to Ethereum network
+        _this._contract.methods.log(value).send({
+            from: _this.web3.eth.defaultAccount,
+            // The Logger contract as originally written uses a maximum of 25070 gas per logged event. If it is rewritten to be more complex, this maximum of 30000 may need to be raised.
+            gas: 3e4,
+            gasPrice: _this._gasPrice
+        }).on('error', (error) => {
+            // Reasons for failure can include:
+            // - Ethereum node unreachable
+            // - Account and password incorrect
+            // - Contract address incorrect
+            // - Insufficient funds in wallet
+            console.error(error);
+        })
+    })
+}
+
+/**
+ * @fn _unlockAccount
+ * @desc Method to temporarily unlock a secured Ethereum account for use in transactions.
+ * @param callback Callback to execute once the account is unlocked.
+ */
+EthereumLogger.prototype._unlockAccount = function (callback) {
+    let _this = this;
+    _this.web3.eth.personal.unlockAccount(
+        _this._account, _this._password, 60 // Unlocked for 60 seconds
+    )
+        .then(callback)
+        .catch((error) => {
+            console.error(`Failed to unlock Ethereum account "${_this._account}". Please verify url, account, and password in config.`);
+            console.error(error, { depth: null });
+        });
+}
+
+
+module.exports = EthereumLogger;

--- a/src/opalInterface.js
+++ b/src/opalInterface.js
@@ -10,6 +10,7 @@ const StatusController = require('./controllers/statusController.js');
 const JobsControllerModule = require('./controllers/jobsController.js');
 const UsersControllerModule = require('./controllers/usersController.js');
 const ClusterControllerModule = require('./controllers/clusterController.js');
+const EthereumLogger = require('./core/ethereumLogger.js');
 const AccessLogger = require('./core/accessLogger.js');
 const AlgoHelper = require('./core/algorithmsHelper.js');
 const CacheHelper = require('./core/cacheHelper.js');
@@ -154,9 +155,17 @@ OpalInterface.prototype._setupInterfaceControllers = function() {
 
     _this.algoHelper = new AlgoHelper(global.opal_interface_config.algoServiceURL, global.opal_interface_config.algorithmsDirectory);
     _this.cacheHelper = new CacheHelper(global.opal_interface_config.cacheURL);
+    _this.ethereumLogger = new EthereumLogger(global.opal_interface_config.ethereum.url,
+                                              global.opal_interface_config.ethereum.account,
+                                              global.opal_interface_config.ethereum.password,
+                                              global.opal_interface_config.ethereum.contract.abi,
+                                              global.opal_interface_config.ethereum.contract.address,
+                                              global.opal_interface_config.ethereum.gasPrice,
+                                              global.opal_interface_config.ethereum.enabled);
     _this.accessLogger = new AccessLogger(_this.db.collection(Constants.EAE_COLLECTION_ACCESS_LOG),
                                                 _this.db.collection(Constants_Opal.OPAL_ILLEGAL_ACCESS_COLLECTION),
-                                                global.opal_interface_config.auditDirectory);
+                                                global.opal_interface_config.auditDirectory,
+                                                _this.ethereumLogger);
     _this.jobsController = new JobsControllerModule(_this.db.collection(Constants.EAE_COLLECTION_JOBS),
                                                     usersManagement,
                                                     _this.db.collection(Constants.EAE_COLLECTION_STATUS),


### PR DESCRIPTION
Disabled by default for people who don't want to deal with Ethereum.

Updates the base image to node:stretch in order to get a new enough version of g++ to build the Ethereum libraries' dependencies.

Setting this up requires the setup tool from https://github.com/OPAL-Project/OPAL-Docker/pull/55.